### PR TITLE
ENH: Add ``skip`` keyword to to_* methods.

### DIFF
--- a/straitlets/builtin_models.py
+++ b/straitlets/builtin_models.py
@@ -114,7 +114,7 @@ class MongoConfig(StrictSerializable):
         return new
 
     hosts = List(
-        Unicode,
+        trait=Unicode,
         minlen=1,
         help=(
             "List of hosts in the replicaset.  "

--- a/straitlets/test_utils.py
+++ b/straitlets/test_utils.py
@@ -28,10 +28,12 @@ def check_attributes(obj, attrs):
         assert getattr(obj, key) == value
 
 
-def assert_serializables_equal(left, right):
+def assert_serializables_equal(left, right, skip=()):
     assert type(left) == type(right)
     assert set(left.trait_names()) == set(right.trait_names())
     for name in left.trait_names():
+        if name in skip:
+            continue
         left_attr = getattr(left, name)
         right_attr = getattr(right, name)
         assert type(left_attr) == type(right_attr)

--- a/straitlets/tests/conftest.py
+++ b/straitlets/tests/conftest.py
@@ -2,33 +2,33 @@ import os
 from ..test_utils import multifixture
 
 
-def _roundtrip_to_dict(traited):
-    return type(traited).from_dict(traited.to_dict())
+def _roundtrip_to_dict(traited, skip=()):
+    return type(traited).from_dict(traited.to_dict(skip=skip))
 
 
-def _roundtrip_to_json(traited):
-    return type(traited).from_json(traited.to_json())
+def _roundtrip_to_json(traited, skip=()):
+    return type(traited).from_json(traited.to_json(skip=skip))
 
 
-def _roundtrip_to_yaml(traited):
-    return type(traited).from_yaml(traited.to_yaml())
+def _roundtrip_to_yaml(traited, skip=()):
+    return type(traited).from_yaml(traited.to_yaml(skip=skip))
 
 
-def _roundtrip_to_base64(traited):
-    return type(traited).from_base64(traited.to_base64())
+def _roundtrip_to_base64(traited, skip=()):
+    return type(traited).from_base64(traited.to_base64(skip=skip))
 
 
-def _roundtrip_to_environ_dict(traited):
+def _roundtrip_to_environ_dict(traited, skip=()):
     environ = {}
-    traited.to_environ(environ)
+    traited.to_environ(environ, skip=skip)
     return type(traited).from_environ(environ)
 
 
-def _roundtrip_to_os_environ(traited):
+def _roundtrip_to_os_environ(traited, skip=()):
     environ = os.environ
     orig = dict(environ)
 
-    traited.to_environ(environ)
+    traited.to_environ(environ, skip=skip)
     try:
         return type(traited).from_environ(environ)
     finally:

--- a/straitlets/tests/test_serializable.py
+++ b/straitlets/tests/test_serializable.py
@@ -67,17 +67,29 @@ def foo_kwargs():
         }
 
 
+@multifixture
+def skip_names():
+    yield ()
+    yield ('enum', 'unicode_', 'int_', 'float_', 'bool_')
+    yield ('dict_', 'list_', 'set_', 'tuple_')
+    yield Foo.class_trait_names()
+
+
 def test_construct_from_kwargs(foo_kwargs):
     instance = Foo(**foo_kwargs)
     check_attributes(instance, foo_kwargs)
 
 
-def test_roundtrip(foo_kwargs, roundtrip_func):
+def test_roundtrip(foo_kwargs, roundtrip_func, skip_names):
     foo = Foo(**foo_kwargs)
-    roundtripped = roundtrip_func(foo)
+    roundtripped = roundtrip_func(foo, skip=skip_names)
     assert isinstance(roundtripped, Foo)
     assert foo is not roundtripped
-    assert_serializables_equal(roundtripped, foo)
+    assert_serializables_equal(roundtripped, foo, skip=skip_names)
+
+    for name in skip_names:
+        with pytest.raises(TraitError):
+            getattr(roundtripped, name)
 
 
 class DynamicDefaults(Serializable):

--- a/straitlets/tests/test_to_primitive.py
+++ b/straitlets/tests/test_to_primitive.py
@@ -10,5 +10,5 @@ def test_base_case():
         to_primitive(SomeRandomClass())
 
     assert str(e.value) == (
-        "Don't know how to instances of SomeRandomClass to primitives."
+        "Don't know how to convert instances of SomeRandomClass to primitives."
     )

--- a/straitlets/to_primitive.py
+++ b/straitlets/to_primitive.py
@@ -8,7 +8,9 @@ from straitlets.dispatch import singledispatch
 @singledispatch
 def to_primitive(obj):
     raise TypeError(
-        "Don't know how to instances of %s to primitives." % type(obj).__name__
+        "Don't know how to convert instances of %s to primitives." % (
+            type(obj).__name__
+        )
     )
 
 _base_handler = to_primitive.dispatch(object)
@@ -25,6 +27,7 @@ def can_convert_to_primitive(type_):
 @to_primitive.register(long)  # Redundant in PY3, but that's fine.
 @to_primitive.register(float)
 @to_primitive.register(unicode)
+@to_primitive.register(bytes)
 @to_primitive.register(type(None))
 def _atom_to_primitive(a):
     return a

--- a/straitlets/traits.py
+++ b/straitlets/traits.py
@@ -5,11 +5,13 @@ Adds the following additional behavior:
 
 - Strict construction/validation of config attributes.
 - Serialization to/from dictionaries containing only primitives.
-- More strict handling of default values than IPython's built-in behavior.
+- More strict handling of default values than traitlets' built-in behavior.
 """
+import inspect
+
 import traitlets as tr
 
-from .to_primitive import can_convert_to_primitive
+from .to_primitive import to_primitive, can_convert_to_primitive
 
 
 class SerializableTrait(tr.TraitType):
@@ -51,19 +53,92 @@ class Bool(SerializableTrait, tr.Bool):
     pass
 
 
-class Set(SerializableTrait, tr.Set):
+# Different traitlets container types use different values for `default_value`.
+# Figure out what to use by inspecting the signatures of __init__.
+def _get_default_value_sentinel(t):
+    # traitlets Tuple does a kwargs.pop rather than specifying the value in its
+    # signature.
+    if t is tr.Tuple:
+        return tr.Undefined
+    argspec = inspect.getargspec(t.__init__)
+    for name, value in zip(reversed(argspec.args), reversed(argspec.defaults)):
+        if name == 'default_value':
+            return value
+
+    raise TypeError(  # pragma: nocover
+        "Can't find default value sentinel for type %s" % t
+    )
+
+_NOTPASSED = object()
+_TRAITLETS_CONTAINER_TYPES = frozenset([tr.List, tr.Set, tr.Dict, tr.Tuple])
+_DEFAULT_VALUE_SENTINELS = {
+    t: _get_default_value_sentinel(t) for t in _TRAITLETS_CONTAINER_TYPES
+}
+
+
+class _ContainerMixin(object):
+
+    def __init__(self, default_value=_NOTPASSED, **kwargs):
+        # traitlets' Container base class converts default_value into args and
+        # kwargs to pass to a factory type and sets those values to (), {} when
+        # default is None or Undefined.  They do this so that not every List
+        # trait shares the same list object as a default value, but each
+        # subclass mucks with the default value in slightly different ways, and
+        # all of them interpret 'default_value not passed' as 'construct an
+        # empty instance', which we don't think is a sane choice of default.
+        #
+        # Rather than trying to intercept all the different ways that traitlets
+        # overrides default values, we just mark whether we've seen an explicit
+        # default value in our constructor, and our make_dynamic_default
+        # function yields Undefined if this wasn't specified.
+        self._have_explicit_default_value = (default_value is not _NOTPASSED)
+        if not self._have_explicit_default_value:
+            # Different traitlets use different values in their __init__
+            # signatures to signify 'not passed'.  Find the correct value to
+            # forward by inspecting our method resolution order.
+            for type_ in type(self).mro():
+                if type_ in _TRAITLETS_CONTAINER_TYPES:
+                    default_value = _DEFAULT_VALUE_SENTINELS[type_]
+                    break
+            else:  # pragma: nocover
+                raise tr.TraitError(
+                    "_ContainerMixin applied to unknown type %s" % type(self)
+                )
+
+        return super(_ContainerMixin, self).__init__(
+            default_value=default_value,
+            **kwargs
+        )
+
+    def validate(self, obj, value):
+        # Ensure that the value is coercible to a primitive.
+        to_primitive(value)
+        return super(_ContainerMixin, self).validate(obj, value)
+
+    def make_dynamic_default(self):
+        if not self._have_explicit_default_value:
+            return None
+        return super(_ContainerMixin, self).make_dynamic_default()
+
+
+class Set(SerializableTrait, _ContainerMixin, tr.Set):
     pass
 
 
-class List(SerializableTrait, tr.List):
+class List(SerializableTrait, _ContainerMixin, tr.List):
     pass
 
 
-class Dict(SerializableTrait, tr.Dict):
-    pass
+class Dict(SerializableTrait, _ContainerMixin, tr.Dict):
+    # For reasons I don't understand, the base Dict constructor intercepts a
+    # default value of Undefined and replaces it with {}.  If None is passed to
+    # the Dict constructor, then we get the desired behavior of barfing unless
+    # a default is explicitly provided.
+    def __init__(self, default_value=None, **kwargs):
+        super(Dict, self).__init__(default_value=default_value, **kwargs)
 
 
-class Tuple(SerializableTrait, tr.Tuple):
+class Tuple(SerializableTrait, _ContainerMixin, tr.Tuple):
     pass
 
 


### PR DESCRIPTION
Allows for generating examples in cases where not all values should be
specified in a config file.  This is useful, for example, when a traited
value should be derived from another traited value via a dynamic
default, and only the root value should be specified in a config file.

Also cleans up several bugs in our handling of defaults for
List/Dict/Set/Tuple.  Previously, these traits were providing empty
default values even in cases where no default had been set.