### PR TITLE
Add support for ssl_ca_certs in MongoConfig.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 sudo: false
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
 
@@ -19,7 +18,6 @@ before_script:
 
 script:
   - if [[ $TRAVIS_PYTHON_VERSION = '2.7' ]]; then tox -e py27; fi
-  - if [[ $TRAVIS_PYTHON_VERSION = '3.4' ]]; then tox -e py34; fi
   - if [[ $TRAVIS_PYTHON_VERSION = '3.5' ]]; then tox -e py35; fi
   - if [[ $TRAVIS_PYTHON_VERSION = '3.6' ]]; then tox -e py36; fi
   - if [[ $TRAVIS_PYTHON_VERSION = '3.7' ]]; then tox -e py37; fi

--- a/straitlets/builtin_models.py
+++ b/straitlets/builtin_models.py
@@ -149,3 +149,8 @@ class MongoConfig(StrictSerializable):
         help="Prefer to connect to non-primary?",
     )
     ssl = Bool(default_value=False, help="Connect via SSL?")
+    ssl_ca_certs = Unicode(
+        allow_none=True,
+        default_value=None,
+        help="Path to concatenated CA certificates.",
+    )

--- a/straitlets/tests/test_builtin_serializables.py
+++ b/straitlets/tests/test_builtin_serializables.py
@@ -48,6 +48,7 @@ def mongo_optional_kwargs():
         'slave_ok': False,
         'prefer_secondary': False,
         'ssl': False,
+        'ssl_ca_certs': '/path/to/ca_cert.pem'
     }
 
 
@@ -135,6 +136,7 @@ def test_mongo_config(mongo_required_kwargs,
         'slave_ok': True,
         'prefer_secondary': True,
         'ssl': False,
+        'ssl_ca_certs': None
     }
 
     without_optionals = MongoConfig(**mongo_required_kwargs)


### PR DESCRIPTION
Add handling for `ssl_ca_certs` for DocumentDB.